### PR TITLE
[WEB-5546] Remove validation for non required address fields in MoneyWorks integration

### DIFF
--- a/resources/invoice_schema.json
+++ b/resources/invoice_schema.json
@@ -119,7 +119,7 @@
                     "example": "NZ"
                 }
             },
-            "required": ["address_1", "city", "country_iso"]
+            "required": ["country_iso"]
         },
 
         "line_item": {

--- a/tests/resources/schema_validation_data/billing_address.php
+++ b/tests/resources/schema_validation_data/billing_address.php
@@ -22,11 +22,11 @@ return [
     ],
     [
         'billing_address',
-        false,
+        true,
         [
             'company_name' => 'Company Inc',
             'person_name' => 'Jo Bloggs',
-            # 'address_1' => '123 Street Road', # Invalid. Is required.
+            # 'address_1' => '123 Street Road', # Valid. Is optional.
             'address_2' => 'Suburbia',
             'address_3' => 'The Stixx',
             'city' => 'Townsville',
@@ -37,14 +37,14 @@ return [
     ],
     [
         'billing_address',
-        false,
+        true,
         [
             'company_name' => 'Company Inc',
             'person_name' => 'Jo Bloggs',
             'address_1' => '123 Street Road',
             'address_2' => 'Suburbia',
             'address_3' => 'The Stixx',
-            # 'city' => 'Townsville', # Invalid. Is required.
+            # 'city' => 'Townsville', # Valid. Is optional.
             'region' => 'Statey',
             'post_code' => '90210',
             'country_iso' => 'NZ'


### PR DESCRIPTION
- Make `address_1` and `city` field optional when validate address
- Update corresponding unit tests